### PR TITLE
Update API for started state

### DIFF
--- a/edx_proctoring/api.py
+++ b/edx_proctoring/api.py
@@ -1341,7 +1341,7 @@ def get_last_exam_completion_date(course_id, username):
     return exam_attempts[0].completed_at if exam_attempts and are_all_exams_attempted else None
 
 
-def get_active_exams_for_user(user_id, course_id=None):
+def get_active_exams_for_user(user_id, course_id=None, exam_id=None):
     """
     This method will return a list of active exams for the user,
     i.e. started_at != None and completed_at == None. Theoretically there
@@ -1362,7 +1362,7 @@ def get_active_exams_for_user(user_id, course_id=None):
     """
     result = []
 
-    student_active_exams = ProctoredExamStudentAttempt.objects.get_active_student_attempts(user_id, course_id)
+    student_active_exams = ProctoredExamStudentAttempt.objects.get_active_student_attempts(user_id, course_id, exam_id)
     for active_exam in student_active_exams:
         # convert the django orm objects
         # into the serialized form.

--- a/edx_proctoring/models.py
+++ b/edx_proctoring/models.py
@@ -267,7 +267,7 @@ class ProctoredExamStudentAttemptManager(models.Manager):
             is_sample_attempt=False,
         ).order_by('-completed_at')
 
-    def get_active_student_attempts(self, user_id, course_id=None):
+    def get_active_student_attempts(self, user_id, course_id=None, exam_id=None):
         """
         Returns the active student exams (user in-progress exams)
         """
@@ -275,6 +275,9 @@ class ProctoredExamStudentAttemptManager(models.Manager):
                                                Q(status=ProctoredExamStudentAttemptStatus.ready_to_submit))
         if course_id is not None:
             filtered_query = filtered_query & Q(proctored_exam__course_id=course_id)
+
+        if exam_id is not None:
+            filtered_query = filtered_query & Q(proctored_exam__id=exam_id)
 
         return self.filter(filtered_query).order_by('-created')  # pylint: disable=no-member
 

--- a/edx_proctoring/views.py
+++ b/edx_proctoring/views.py
@@ -504,7 +504,7 @@ class StudentProctoredExamAttemptCollection(ProctoredAPIView):
         HTTP GET Handler. Returns the status of the exam attempt.
         """
 
-        exams = get_active_exams_for_user(request.user.id)
+        exams = get_active_exams_for_user(request.user.id, exam_id=exam_id)
 
         if exams:
             exam_info = exams[0]


### PR DESCRIPTION
**Description:**
If a course has multiple timed exams, information on each of the exams individually is not available. In a condition where the user starts multiple exams at same time then only latest attempt information is returned, which can be misleading. The changes are below:

- Added the `exam_id` parameter to filter API data.


**JIRA:**
https://extranet.who.int/jira/browse/KBLDS-804